### PR TITLE
Replace `renderCallback` with `window.onresize`

### DIFF
--- a/src/graphic/js/graphic.js
+++ b/src/graphic/js/graphic.js
@@ -12,9 +12,9 @@ const draw = () => {
   // step 7: set up interactions
 }
 
-const resize = () => {};
+window.onresize = () => { };
 
-window.onload = function () {
-  const pymChild = new pym.Child({ renderCallback: resize, polling: 500 });
+window.onload = () => {
+  const pymChild = new pym.Child({ polling: 500 });
   pymChild.sendHeight();
 };


### PR DESCRIPTION
This removes the need to have Pym `renderCallback` correctly fire by listening to the window event instead to handle resize. 

On rare occasions, the resize function is called twice when the window loads. It may have something to do with the `pymChild` polling or height sending, but I haven't been able to consistently replicate double firing.

### Alternatives

We may want to consider using the d3 idiomatic equivalent:

```javascript
d3.select(window).on("resize", () => {
    console.log("resize");
});
```

The [on](https://github.com/d3/d3-selection#selection_on) function allows for some more flexibility in that you can add different listeners to the same event (e.g. [small multiple resize handling](https://github.com/MichiganDaily/bore/blob/4c0592fadc59e3bc3bfca264f8fa087c9eef9699/src/bore.js#L115)).

### Linked issues 

 Close #6.