### PR TITLE
Echo link and reminder after deployment

### DIFF
--- a/Makefile.project
+++ b/Makefile.project
@@ -22,10 +22,9 @@ build:
 	rm -rf dist/*
 	yarn run build
 
-SITE = "datagraphics.michigandaily.com"
-REPO = $(shell basename -s .git `git remote get-url origin`)
-PAGES = "https://github.com/MichiganDaily/$(REPO)/settings/pages"
-
+gh-pages: SITE = $(shell python -c "import json; print(json.load(open('config.json'))['deployment']);")
+gh-pages: REPO = $(shell basename -s .git `git remote get-url origin`)
+gh-pages: PAGES = "https://github.com/MichiganDaily/$(REPO)/settings/pages"
 gh-pages: build-prod
 	(cd dist; git add --all)
 	(cd dist; git commit -m "Build output as of $(shell git log '--format=format:%H' main -1)" || echo "No changes to commit.")

--- a/config.json
+++ b/config.json
@@ -4,6 +4,8 @@
   "byline": "Firstname Lastname",
   "source": "Source: This is the source",
 
+  "deployment": "https://datagraphics.michigandaily.com",
+
   "ga_id": "UA-168080597-1",
 
   "render": {


### PR DESCRIPTION
### Output

<img width="782" alt="Screen Shot 2021-08-19 at 11 53 01 PM" src="https://user-images.githubusercontent.com/44459660/130176552-c8e42137-70d7-4c19-bc37-68ed511ca258.png">

### Further considerations

Currently, the link does not begin with http or https. Should it? Pasting into the browser works correctly. If the link starts with http or https, VSCode allows you to click on it to open in a tab. I assume other editors or terminals also do this.

How can we determine if the deployed graphic uses HTTPS? Could we hit the URL with curl or wget? If it is already HTTPS enforced, should we get rid of the reminder?

Should we put "datagraphics.michigandaily.com" out of the Makefile and into the config?

### Linked issues

Resolves #13 