### PR TITLE
Set default preview width to 288px

### DIFF
--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -7,7 +7,7 @@ body {
 
 #graphic {
   border: 1px solid $gray;
-  width: 780px;
+  width: 288px;
   resize: horizontal;
   overflow-x: auto;
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -48,11 +48,11 @@ window.onload = () => {
   $("#desktop-preview").addEventListener("click", () => {
     setWidth(780);
   });
-  $("#small-mobile-preview").addEventListener("click", () => {
-    setWidth(288);
-  });
   $("#large-mobile-preview").addEventListener("click", () => {
     setWidth(338);
+  });
+  $("#small-mobile-preview").addEventListener("click", () => {
+    setWidth(288);
   });
 
   const urlInput = $("#url-input");


### PR DESCRIPTION
#### What's this PR do?

Sets the default iframe container width to 288px.

#### Are there any relevant screenshots?

#### Why are we doing this? How does it help us?

The majority of our users use a phone to experience our articles. We have a predisposition to developing our graphics in a desktop-first mindset. Yes, graphics should work on a desktop. **But they must work on mobile devices for the sake of our audience.** This change will at least nudge people to start developing mobile-first. 

#### How should this be manually tested?

#### Are there any smells or added technical debt to note?

#### What are relevant issues or links?

#40 

#### Have you done the following, if applicable:

* [x] Performed a self-review of the code?
* [x] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
