### PR TITLE
Remove site from public URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ gh-pages: REPO = $(shell basename -s .git `git remote get-url origin`)
 gh-pages: PAGES = "https://github.com/MichiganDaily/$(REPO)/settings/pages"
 gh-pages:
 	yarn clean
-	yarn run parcel build --no-scope-hoist src/index.html --public-url $(SITE)/$(REPO)
+	yarn run parcel build --no-scope-hoist src/index.html --public-url /$(REPO)
 	(cd dist; git add --all)
 	(cd dist; git commit -m "Build output as of $(shell git log '--format=format:%H' main -1)" || echo "No changes to commit.")
 	(cd dist; git pull -s ours --no-edit origin gh-pages --allow-unrelated-histories || echo "Could not pull from origin.")


### PR DESCRIPTION
#### What's this PR do?

Removes the site from the public URL in the `gh-pages` Makefile target.

#### Are there any relevant screenshots?

#### Why are we doing this? How does it help us?

Allows more fluid movement between domains without having to redeploy.

#### How should this be manually tested?

#### Are there any smells or added technical debt to note?

#### What are relevant issues or links?

#### Have you done the following, if applicable:

* [ ] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
